### PR TITLE
Add a layer to a viewer with drag and drop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Execute integration tests
         working-directory: ui-tests
         run: |
-          jlpm run test
+          jlpm run test --retries=3
 
       - name: Upload Playwright Test report
         if: always()

--- a/glue_jupyterlab/glue_session.py
+++ b/glue_jupyterlab/glue_session.py
@@ -349,6 +349,14 @@ class SharedGlueSession:
             ydoc=self._sessionYDoc,
         )
 
+    def add_viewer_layer(self, tab_name: str, viewer_name: str, data_name:str) -> None:
+        """Add a layer with new dataset to a viewer"""
+        viewer = self._viewers.get(tab_name, {}).get(viewer_name, {}).get("widget", None)
+        if not viewer:
+            return
+        data = self._data[data_name]
+        viewer.add_data(data)
+
     def add_data(self, file_path: str) -> None:
         """Add a new data file to the session"""
         relative_path = Path(file_path).relative_to(Path(self._path).parent)

--- a/glue_jupyterlab/glue_session.py
+++ b/glue_jupyterlab/glue_session.py
@@ -349,9 +349,11 @@ class SharedGlueSession:
             ydoc=self._sessionYDoc,
         )
 
-    def add_viewer_layer(self, tab_name: str, viewer_name: str, data_name:str) -> None:
+    def add_viewer_layer(self, tab_name: str, viewer_name: str, data_name: str) -> None:
         """Add a layer with new dataset to a viewer"""
-        viewer = self._viewers.get(tab_name, {}).get(viewer_name, {}).get("widget", None)
+        viewer = (
+            self._viewers.get(tab_name, {}).get(viewer_name, {}).get("widget", None)
+        )
         if not viewer:
             return
         data = self._data[data_name]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,6 +19,8 @@ export namespace CommandIDs {
   export const openControlPanel = 'glue-control:open-control-panel';
 
   export const closeControlPanel = 'glue-control:close-control-panel';
+
+  export const addViewerLayer = 'glue-control:add-viewer-layer';
 }
 
 export interface INewViewerArgs {

--- a/src/leftPanel/plugin.ts
+++ b/src/leftPanel/plugin.ts
@@ -229,6 +229,23 @@ function addCommands(
       controlModel.clearConfig();
     }
   });
+
+  commands.addCommand(CommandIDs.addViewerLayer, {
+    execute: async args => {
+      const kernel = controlModel.currentSessionKernel();
+      if (kernel === undefined) {
+        // TODO Show an error dialog
+        return;
+      }
+
+      const code = `
+      GLUE_SESSION.add_viewer_layer("${args.tab}", "${args.viewer}", "${args.data}")
+      `;
+
+      const future = kernel.requestExecute({ code }, false);
+      await future.done;
+    }
+  });
 }
 
 export const controlPanel: JupyterFrontEndPlugin<void> = {

--- a/src/viewPanel/sessionWidget.ts
+++ b/src/viewPanel/sessionWidget.ts
@@ -96,8 +96,14 @@ export class SessionWidget extends BoxPanel {
   }
 
   private async _ondrop(event: DragEvent) {
-    const datasetId = event.dataTransfer?.getData(DATASET_MIME);
+    const target = event.target as HTMLElement;
+    const viewer = target.closest('.grid-stack-item.glue-item');
+    // No-op if the target is a viewer, it will be managed by the viewer itself.
+    if (viewer) {
+      return;
+    }
 
+    const datasetId = event.dataTransfer?.getData(DATASET_MIME);
     const items: IDict<string> = {
       Histogram: CommandIDs.new1DHistogram,
       '1D Profile': CommandIDs.new1DProfile,

--- a/src/viewPanel/tabLayout.ts
+++ b/src/viewPanel/tabLayout.ts
@@ -318,6 +318,21 @@ export class TabLayout extends Layout {
       gridItem: item as any
     });
   }
+
+  /**
+   * Request to add a layer with a dataset to the viewer.
+   *
+   * @param item - the viewer where to add a layer.
+   * @param dataName - the data to add to the viewer.
+   */
+  private _addViewerLayer(item: GridStackItem, dataName: string): void {
+    this._commands.execute(CommandIDs.addViewerLayer, {
+      tab: item.tabName,
+      viewer: item.cellIdentity,
+      data: dataName
+    });
+  }
+
   /**
    * Handle change-event messages sent to from gridstack.
    */
@@ -375,6 +390,12 @@ export class TabLayout extends Layout {
         break;
       case 'edit':
         this._handleEdit(sender);
+        break;
+      case 'layer':
+        if (!change.dataLayer) {
+          return;
+        }
+        this._addViewerLayer(sender, change.dataLayer);
         break;
       default:
         break;

--- a/src/viewPanel/tabView.ts
+++ b/src/viewPanel/tabView.ts
@@ -153,7 +153,8 @@ export class TabView extends Widget {
         cell: out,
         itemTitle: itemTitle.match(/($[a-z])|[A-Z][^A-Z]+/g)?.join(' '),
         pos: viewerData.pos,
-        size: viewerData.size
+        size: viewerData.size,
+        tabName: tabName
       });
       const cellOutput = item.cellOutput as SimplifiedOutputArea;
       if (this._context) {


### PR DESCRIPTION
![Peek 2023-07-06 22-09](https://github.com/QuantStack/glue-jupyterlab/assets/32258950/4cf6ce73-3dd2-4966-8cb0-31c803cc4aba)

The idea is:
- to catch the drop event on the viewer widget (if so, the event is cancelled for the `sessionWidget`)
- the viewer widget send a `change` signal to `tabLayout`, which execute the command in the kernel.

*EDIT*:
Some ui-tests failed for snapshot error not related to this PR, so I added `--retries=3` when running the playwright tests.